### PR TITLE
Fix floating-point gaps in switch range patterns

### DIFF
--- a/battery/BatteryView.swift
+++ b/battery/BatteryView.swift
@@ -6,9 +6,9 @@ struct BatteryView: View {
     private var batteryColor: LinearGradient {
         let colors: [Color]
         switch percentage {
-        case 0...20:
+        case 0..<21:
             colors = [Color(red: 1.0, green: 0.3, blue: 0.3), Color(red: 0.9, green: 0.1, blue: 0.1)]
-        case 21...50:
+        case 21..<50:
             colors = [Color(red: 1.0, green: 0.8, blue: 0.2), Color(red: 1.0, green: 0.6, blue: 0.0)]
         default:
             colors = [Color(red: 0.4, green: 0.9, blue: 0.4), Color(red: 0.2, green: 0.7, blue: 0.2)]

--- a/battery/ContentView.swift
+++ b/battery/ContentView.swift
@@ -167,9 +167,9 @@ struct ContentView: View {
     
     var sliderAccentColor: Color {
         switch batteryPercentage {
-        case 0...20:
+        case 0..<21:
             return Color(red: 1.0, green: 0.3, blue: 0.3)
-        case 21...50:
+        case 21..<50:
             return Color(red: 1.0, green: 0.7, blue: 0.2)
         default:
             return Color(red: 0.3, green: 0.9, blue: 0.3)
@@ -183,15 +183,15 @@ struct ContentView: View {
     
     var currentEmoji: String {
         switch batteryPercentage {
-        case 0...16:
+        case 0..<17:
             return "😵"  // 完全沒電
-        case 17...33:
+        case 17..<34:
             return "😫"  // 很累
-        case 34...50:
+        case 34..<51:
             return "😕"  // 有點累
-        case 51...67:
+        case 51..<68:
             return "😐"  // 普通
-        case 68...84:
+        case 68..<85:
             return "🙂"  // 還不錯
         default:
             return "😄"  // 滿電


### PR DESCRIPTION
Replace closed ranges with half-open ranges to handle Double values correctly and eliminate gaps between ranges (e.g., values like 16.5 previously fell through to `default`).

To demo the issue, we can change the `Slider`'s step to `0.1`, and drag the value to ~16.5%, then we will see an incorrect emoji.

> <img width="808" height="1856" alt="CleanShot 2025-09-14 at 08 13 34@2x" src="https://github.com/user-attachments/assets/acc6a11a-c118-4e67-9848-d2bf69394f17" />

For more information, see:
- https://developer.apple.com/documentation/swift/closedrange
- https://developer.apple.com/documentation/swift/range